### PR TITLE
IPv6で外部に接続できるようにする

### DIFF
--- a/packages/mailforwarder-infrastructure/package-lock.json
+++ b/packages/mailforwarder-infrastructure/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "packages",
 			"version": "0.1.0",
 			"dependencies": {
-				"aws-cdk-lib": "2.126.0",
+				"aws-cdk-lib": "2.135.0",
 				"constructs": "^10.0.0",
 				"source-map-support": "^0.5.16"
 			},
@@ -1311,9 +1311,9 @@
 			}
 		},
 		"node_modules/aws-cdk-lib": {
-			"version": "2.126.0",
-			"resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.126.0.tgz",
-			"integrity": "sha512-HlwBYiqNCfhPUyozjoV4zJIBgH0adE/zTVATmeaM1jcNGs6jwkPMpWsF75JuXOoVtkcfpBFyNKloGd82nTiB0A==",
+			"version": "2.135.0",
+			"resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.135.0.tgz",
+			"integrity": "sha512-0RcmhPqJyMFgXqjESv+LilL7TfOQ7uZ4G125hp5/sSoaM7IFz/L3KDAUKVW/01rrebOQo0NZR9M7WIU3JJ7ezQ==",
 			"bundleDependencies": [
 				"@balena/dockerignore",
 				"case",
@@ -1324,7 +1324,8 @@
 				"punycode",
 				"semver",
 				"table",
-				"yaml"
+				"yaml",
+				"mime-types"
 			],
 			"dependencies": {
 				"@aws-cdk/asset-awscli-v1": "^2.2.202",
@@ -1333,12 +1334,13 @@
 				"@balena/dockerignore": "^1.0.2",
 				"case": "1.6.3",
 				"fs-extra": "^11.2.0",
-				"ignore": "^5.3.0",
+				"ignore": "^5.3.1",
 				"jsonschema": "^1.4.1",
+				"mime-types": "^2.1.35",
 				"minimatch": "^3.1.2",
 				"punycode": "^2.3.1",
-				"semver": "^7.5.4",
-				"table": "^6.8.1",
+				"semver": "^7.6.0",
+				"table": "^6.8.2",
 				"yaml": "1.10.2"
 			},
 			"engines": {
@@ -1470,7 +1472,7 @@
 			"license": "ISC"
 		},
 		"node_modules/aws-cdk-lib/node_modules/ignore": {
-			"version": "5.3.0",
+			"version": "5.3.1",
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -1525,6 +1527,25 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/aws-cdk-lib/node_modules/mime-db": {
+			"version": "1.52.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/mime-types": {
+			"version": "2.1.35",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/aws-cdk-lib/node_modules/minimatch": {
 			"version": "3.1.2",
 			"inBundle": true,
@@ -1553,7 +1574,7 @@
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/semver": {
-			"version": "7.5.4",
+			"version": "7.6.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -1607,7 +1628,7 @@
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/table": {
-			"version": "6.8.1",
+			"version": "6.8.2",
 			"inBundle": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -1761,7 +1782,8 @@
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
 		},
 		"node_modules/base": {
 			"version": "0.11.2",
@@ -1837,6 +1859,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -2112,7 +2135,8 @@
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"node_modules/constructs": {
 			"version": "10.0.39",
@@ -4332,7 +4356,6 @@
 			"version": "1.51.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
 			"integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -4341,7 +4364,6 @@
 			"version": "2.1.34",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
 			"integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-			"dev": true,
 			"dependencies": {
 				"mime-db": "1.51.0"
 			},
@@ -4362,6 +4384,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},

--- a/packages/mailforwarder-infrastructure/package.json
+++ b/packages/mailforwarder-infrastructure/package.json
@@ -22,7 +22,7 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.126.0",
+    "aws-cdk-lib": "2.135.0",
     "constructs": "^10.0.0",
     "mailforwarder-functions": "^0.1.0",
     "source-map-support": "^0.5.16"


### PR DESCRIPTION
LightsailがIPv4アドレスがあるインスタンスに対して値上げするので、IPv6のみのインスタンスに差し替える。
それに伴い、LambdaからIPv6で出られるようにする。