### PR TITLE
ダメになったメールアドレスを捨てられる機能を追加する

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,7 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# GitHub Copilot persisted chat sessions
+/copilot/chatSessions

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/packages/mailforwarder-functions/src/constants.ts
+++ b/packages/mailforwarder-functions/src/constants.ts
@@ -3,6 +3,7 @@ const constants = {
     forwardingTableName: process.env.DDB_FORWARDING_TABLE_NAME || "",
     mappingTableName: process.env.DDB_MAPPING_TABLE_NAME || "",
     accountsTableName: process.env.DDB_ACCOUNTS_TABLE_NAME || "",
+    dropConfigsTableName: process.env.DDB_DROP_CONFIGS_TABLE_NAME || "",
   },
   queue: {
     forwardingQueueUrl: process.env.SQS_FORWARDING_QUEUE_URL || "",

--- a/packages/mailforwarder-functions/src/container.ts
+++ b/packages/mailforwarder-functions/src/container.ts
@@ -71,6 +71,7 @@ class AppContainer {
       this.accountsRepository = new AccountsRepositoryImplementation(
         this.getDynamoDbDatastore(),
         constants.tables.accountsTableName,
+        constants.tables.dropConfigsTableName,
       );
     }
     return this.accountsRepository;

--- a/packages/mailforwarder-functions/src/datastore/dynamodb/interface.ts
+++ b/packages/mailforwarder-functions/src/datastore/dynamodb/interface.ts
@@ -1,6 +1,7 @@
 import { DocumentClient } from "aws-sdk/clients/dynamodb";
 
 export interface IDatabaseObject<T> {
+  // FIXME: itemがundefinedになることがある(undefinedにならないように、戻り値がIDatabaseObject<T>?になるようにする等の対策をする)
   item: T;
   oldItem?: T;
 }

--- a/packages/mailforwarder-functions/src/models/index.ts
+++ b/packages/mailforwarder-functions/src/models/index.ts
@@ -4,11 +4,12 @@ export const ForwardingStatus = {
   Received: "received",
   Completed: "completed",
   Failed: "failed",
+  Dropped: "dropped",
 };
 export type ForwardingStatus = typeof ForwardingStatus[keyof typeof ForwardingStatus];
 
 export interface Forwarding {
-  forwardingId: string;
+  forwardingId: string;  // ${objectKey}/${mappingKey}
   createdAt: number;
   forwardedAt?: number;
   objectKey: string;
@@ -30,4 +31,11 @@ export interface Account {
   accountId: string;
   createdAt: number;
   accountEmail: string;
+}
+
+export interface DropConfig {
+  dropConfigId: string; // ${accountId}/${dropAddress}
+  accountId: string;
+  dropAddress: string;
+  createdAt: number;
 }

--- a/packages/mailforwarder-functions/src/repositories/accounts/implements.ts
+++ b/packages/mailforwarder-functions/src/repositories/accounts/implements.ts
@@ -27,10 +27,10 @@ class AccountsRepositoryImplementation implements AccountsRepository {
 
   public async isDropAsync(accountId: string, recipient: string): Promise<boolean | undefined> {
     try {
-      await this.dynamoDb.getItemAsync<DropConfig>(this.dropConfigsTableName, {
+      const item = await this.dynamoDb.getItemAsync<DropConfig>(this.dropConfigsTableName, {
         dropConfigId: `${accountId}/${recipient}`,
       });
-      return true;
+      return item.item !== undefined;
     } catch {
       // TODO: Not Found のときはfalse、それ以外はundefinedを返す
       return false;

--- a/packages/mailforwarder-functions/src/repositories/accounts/implements.ts
+++ b/packages/mailforwarder-functions/src/repositories/accounts/implements.ts
@@ -1,14 +1,16 @@
 import { DynamoDbDatastore } from "../../datastore/dynamodb";
-import { Account } from "../../models";
+import {Account, DropConfig} from "../../models";
 import { AccountsRepository } from "./interface";
 
 class AccountsRepositoryImplementation implements AccountsRepository {
   private readonly dynamoDb: DynamoDbDatastore;
   private readonly accountsTableName: string;
+  private readonly dropConfigsTableName: string;
 
-  public constructor(dynamoDb: DynamoDbDatastore, accountsTableName: string) {
+  public constructor(dynamoDb: DynamoDbDatastore, accountsTableName: string, dropConfigsTableName: string) {
     this.dynamoDb = dynamoDb;
     this.accountsTableName = accountsTableName;
+    this.dropConfigsTableName = dropConfigsTableName;
   }
 
   public async getAsync(accountId: string): Promise<Account | undefined> {
@@ -20,6 +22,18 @@ class AccountsRepositoryImplementation implements AccountsRepository {
       ).item;
     } catch {
       return undefined;
+    }
+  }
+
+  public async isDropAsync(accountId: string, recipient: string): Promise<boolean | undefined> {
+    try {
+      await this.dynamoDb.getItemAsync<DropConfig>(this.dropConfigsTableName, {
+        dropConfigId: `${accountId}/${recipient}`,
+      });
+      return true;
+    } catch {
+      // TODO: Not Found のときはfalse、それ以外はundefinedを返す
+      return false;
     }
   }
 }

--- a/packages/mailforwarder-functions/src/repositories/accounts/interface.ts
+++ b/packages/mailforwarder-functions/src/repositories/accounts/interface.ts
@@ -2,4 +2,5 @@ import { Account } from "../../models";
 
 export interface AccountsRepository {
   getAsync(accountId: string): Promise<Account | undefined>;
+  isDropAsync(accountId: string, recipient: string): Promise<boolean | undefined>;
 }

--- a/packages/mailforwarder-functions/src/repositories/forwarding/implements.ts
+++ b/packages/mailforwarder-functions/src/repositories/forwarding/implements.ts
@@ -107,7 +107,7 @@ class ForwardingRepositoryImplementation implements ForwardingRepository {
 
   public async markDroppedAsync(forwardingId: string): Promise<void> {
     try {
-      console.warn(`[${forwardingId}] mark failed`);
+      console.warn(`[${forwardingId}] mark dropped`);
       await this.dynamoDb.updateItemAsync<Forwarding>(
         this.forwardingTableName,
         { forwardingId },

--- a/packages/mailforwarder-functions/src/repositories/forwarding/implements.ts
+++ b/packages/mailforwarder-functions/src/repositories/forwarding/implements.ts
@@ -104,6 +104,28 @@ class ForwardingRepositoryImplementation implements ForwardingRepository {
       // nop
     }
   }
+
+  public async markDroppedAsync(forwardingId: string): Promise<void> {
+    try {
+      console.warn(`[${forwardingId}] mark failed`);
+      await this.dynamoDb.updateItemAsync<Forwarding>(
+        this.forwardingTableName,
+        { forwardingId },
+        {},
+        {
+          UpdateExpression: "set #status = :status",
+          ExpressionAttributeNames: {
+            "#status": "status",
+          },
+          ExpressionAttributeValues: {
+            ":status": ForwardingStatus.Dropped,
+          },
+        },
+      );
+    } catch {
+      // nop
+    }
+  }
 }
 
 export default ForwardingRepositoryImplementation;

--- a/packages/mailforwarder-functions/src/repositories/forwarding/interface.ts
+++ b/packages/mailforwarder-functions/src/repositories/forwarding/interface.ts
@@ -4,5 +4,6 @@ export interface ForwardingRepository {
   getAsync(forwardingId: string): Promise<Forwarding | undefined>;
   requestForwardAsync(forwarding: Forwarding): Promise<void>;
   markFailedAsync(forwardingId: string): Promise<void>;
+  markDroppedAsync(forwardingId: string): Promise<void>;
   executeForwardAsync(forwarding: Forwarding, accountEmail: string): Promise<boolean>;
 }

--- a/packages/mailforwarder-functions/src/usecases/forwarding/implements.ts
+++ b/packages/mailforwarder-functions/src/usecases/forwarding/implements.ts
@@ -34,7 +34,7 @@ class ForwardingUseCaseImplementation implements ForwardingUseCase {
 
     // Drop
     const drop = await this.accountsRepository.isDropAsync(account.accountId, forwarding.recipient);
-    if (drop) {
+    if (drop === true) {
       console.info(`[${inputForwarding.forwardingId}] drop`);
       await this.forwardingRepository.markDroppedAsync(forwarding.forwardingId);
       return;

--- a/packages/mailforwarder-functions/src/usecases/forwarding/implements.ts
+++ b/packages/mailforwarder-functions/src/usecases/forwarding/implements.ts
@@ -13,6 +13,7 @@ class ForwardingUseCaseImplementation implements ForwardingUseCase {
   }
 
   public async handleForwardEventAsync(inputForwarding: Forwarding): Promise<void> {
+    // Pre-check
     const forwarding = await this.forwardingRepository.getAsync(inputForwarding.forwardingId);
     if (!forwarding) {
       console.warn(`[${inputForwarding.forwardingId}] forwarding not found`);
@@ -22,12 +23,24 @@ class ForwardingUseCaseImplementation implements ForwardingUseCase {
       console.warn(`[${inputForwarding.forwardingId}] already finished`);
       return;
     }
+
+    // Account
     const account = await this.accountsRepository.getAsync(forwarding.accountId);
     if (!account) {
       console.warn(`[${inputForwarding.forwardingId}] account not found`);
       await this.forwardingRepository.markFailedAsync(forwarding.forwardingId);
       return;
     }
+
+    // Drop
+    const drop = await this.accountsRepository.isDropAsync(account.accountId, forwarding.recipient);
+    if (drop) {
+      console.info(`[${inputForwarding.forwardingId}] drop`);
+      await this.forwardingRepository.markDroppedAsync(forwarding.forwardingId);
+      return;
+    }
+
+    // Forwarding
     console.info(`[${inputForwarding.forwardingId}] forwarding start`);
     await this.forwardingRepository.executeForwardAsync(forwarding, account.accountEmail);
     console.info(`[${inputForwarding.forwardingId}] forwarding end`);

--- a/packages/mailforwarder-infrastructure/lib/packages-stack.ts
+++ b/packages/mailforwarder-infrastructure/lib/packages-stack.ts
@@ -75,10 +75,26 @@ export class PackagesStack extends Stack {
         name: "createdAt", type: ddb.AttributeType.NUMBER
       },
     })
+    const dropConfigsTable = new ddb.Table(this, "DropConfigsTable", {
+      partitionKey: {
+        name: "dropConfigId",
+        type: ddb.AttributeType.STRING
+      },
+      billingMode: ddb.BillingMode.PAY_PER_REQUEST,
+    });
+    dropConfigsTable.grantReadWriteData(functionRole);
+    dropConfigsTable.addGlobalSecondaryIndex({
+      indexName: "dropConfigAccountIndex",
+      partitionKey: { name: "accountId", type: ddb.AttributeType.STRING },
+      sortKey: {
+        name: "createdAt", type: ddb.AttributeType.NUMBER
+      },
+    })
     const tableNameEnvironments = {
       DDB_FORWARDING_TABLE_NAME: forwardingTable.tableName,
       DDB_MAPPING_TABLE_NAME: accountMappingsTable.tableName,
       DDB_ACCOUNTS_TABLE_NAME: accountsTable.tableName,
+      DDB_DROP_CONFIGS_TABLE_NAME: dropConfigsTable.tableName,
     };
 
     // queue


### PR DESCRIPTION
流出の憂き目になったアドレスにはフィッシングメールしか届くようになる。
登録先ごとにメールアドレスを変えているし、流出されていると判断したときはサービスに登録するアドレスを変更するかサービス自体を解約するため、そうなってしまったメールアドレスに届くメールはすべて不要になるため捨てることができる。

捨てる判断をしたメールアドレスに届いたメールはメールボックスに配信されないようにする。