### PR TITLE
hotfix/0.3.1

### DIFF
--- a/packages/mailforwarder-functions/src/usecases/receive/implements.ts
+++ b/packages/mailforwarder-functions/src/usecases/receive/implements.ts
@@ -33,7 +33,7 @@ class ReceiveUseCaseImplementation implements ReceiveUseCase {
   }
 
   private async processReceiveMessage(message: SESMessage, recipient: string): Promise<void> {
-    const match = /^([^@+]*)(?:\+[^@]+)?@(.*)$/.exec(recipient);
+    const match = /^([^@+]*)(?:\+[^@]+)?@(.*)$/.exec(recipient.toLowerCase());
     if (!match) {
       console.warn(`[${message.mail.messageId}/${recipient}]: invalid recipient format`);
       return;


### PR DESCRIPTION
- レシピエント(To)が大文字だとフィルタリングルールにマッチしなくなるので小文字に正規化する